### PR TITLE
fix for issue - https://github.com/singnet/simulation/issues/4

### DIFF
--- a/simulation/SnetSim.py
+++ b/simulation/SnetSim.py
@@ -30,6 +30,9 @@ class SnetSim(Model):
 
         #save the config with the output
         filename = config['parameters']['output_path'] + study_path
+        #make sure the output_path folder exists
+        if not os.path.exists(config['parameters']['output_path']):
+            os.makedirs(config['parameters']['output_path'])
         pretty = json.dumps(config, indent=2, separators=(',', ':'))
         with open(filename, 'w') as outfile:
             outfile.write(pretty)


### PR DESCRIPTION
I tried to replicate your issue and found out that the directory onehumantwobots did not exist in the repository and that it was also not created if it did not exist. Therefore it could not generate the necessary data. This folder is set as the ouput_path by the onehumantwobots.json file.

I made a pull request from my fork in which it works with the notebook by inserting a check and if necessary the creation of the folder.

PS. shameless  plug - I applied to SingularityNET and would be happy to work with you on this simulation :) - my mail 4robinlehmann@gmail.com